### PR TITLE
fixbug:新版cesium使用构造函数创建图层时需要额外的参数会导致页面报错

### DIFF
--- a/src/lib/CesiumHeat.js
+++ b/src/lib/CesiumHeat.js
@@ -153,14 +153,13 @@ export default (Cesium) => class CesiumHeat {
    * 更新cesium显示
    * @param {*} updateHeat 
    */
-  updateCesium(updateHeat) {
+  async updateCesium(updateHeat) {
     if (this.layer) {
       this.viewer.scene.imageryLayers.remove(this.layer)
     }
     updateHeat && this.updateHeatmap()
 
-    let provider = new Cesium.SingleTileImageryProvider({
-      url: this.heatmap.getDataURL(),
+    let provider = await Cesium.SingleTileImageryProvider.fromUrl(this.heatmap.getDataURL(),{
       rectangle: Cesium.Rectangle.fromDegrees(...this.bbox)
     })
     this.layer = this.viewer.scene.imageryLayers.addImageryProvider(provider)


### PR DESCRIPTION
使用Cesium.SingleTileImageryProvide构造器在新版中需要传入tileWidth，tileHeight两个参数指定瓦片尺寸，改为静态方法fromUrl获取即可；